### PR TITLE
Forecasting bug fix

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,3 +17,4 @@ dependencies:
   - yaml
   - gdown
   - conda-build
+  - cfgrib


### PR DESCRIPTION
This updated PR addresses two bugs.
- Fixes forecasted evaporation not being generated due to lack of surface area time-series. Now surface area is filled in the forecasting window by forward filling, which is used for estimating the evaporation.
- Fixes a bug when RAT-Forecasting would fail if Tmin > Tmax forecasted by GFS (few cases, but can lead to run failing). In such scenarios, Tmin will be set equal to Tmax such that the forecasting module doesn't throw an error.